### PR TITLE
add support for filtering with multiple environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 .idea/
+
+# Don't commit config files :O
+decima.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+---
 language: scala
 scala:
   - 2.11.6
+script:
+  - sbt +compile +styleCheck +coverage +test +assembly 
 

--- a/src/main/scala/com/socrata/decima/data_access/DeployAccess.scala
+++ b/src/main/scala/com/socrata/decima/data_access/DeployAccess.scala
@@ -8,8 +8,8 @@ import scala.slick.driver.PostgresDriver.simple.Database
 
 trait DeployAccess {
   def createDeploy(deploy: DeployForCreate): Either[Exception, Deploy]
-  def currentDeploymentState(environment: Option[String], service: Option[String]): Seq[Deploy]
-  def deploymentHistory(environment: Option[String], service: Option[String], limit: Int): Seq[Deploy]
+  def currentDeploymentState(environments: Option[Array[String]], services: Option[Array[String]]): Seq[Deploy]
+  def deploymentHistory(environments: Option[Array[String]], services: Option[Array[String]], limit: Int): Seq[Deploy]
 }
 
 case class DeployAccessWithPostgres(db: Database, dao: DeployDAO with DatabaseDriver) extends DeployAccess {
@@ -18,13 +18,14 @@ case class DeployAccessWithPostgres(db: Database, dao: DeployDAO with DatabaseDr
       dao.createDeploy(deploy)
     }
 
-  override def currentDeploymentState(environment: Option[String], service: Option[String]): Seq[Deploy] =
+  override def currentDeploymentState(environments: Option[Array[String]], services: Option[Array[String]]): Seq[Deploy] =
     db.withSession { implicit session =>
-      dao.currentDeployment(environment, service)
+      dao.currentDeployment(environments, services)
     }
 
-  override def deploymentHistory(environment: Option[String], service: Option[String], limit: Int): Seq[Deploy] =
+  override def deploymentHistory(environments: Option[Array[String]], services: Option[Array[String]], limit: Int): Seq[Deploy] =
     db.withSession { implicit session =>
-      dao.deploymentHistory(environment, service, limit)
+      //dao.deploymentHistory(environment, service, limit)
+      dao.deploymentHistory(environments, services, limit)
     }
 }

--- a/src/main/scala/com/socrata/decima/data_access/DeployAccess.scala
+++ b/src/main/scala/com/socrata/decima/data_access/DeployAccess.scala
@@ -18,14 +18,16 @@ case class DeployAccessWithPostgres(db: Database, dao: DeployDAO with DatabaseDr
       dao.createDeploy(deploy)
     }
 
-  override def currentDeploymentState(environments: Option[Array[String]], services: Option[Array[String]]): Seq[Deploy] =
+  override def currentDeploymentState(environments: Option[Array[String]],
+                                      services: Option[Array[String]]): Seq[Deploy] =
     db.withSession { implicit session =>
       dao.currentDeployment(environments, services)
     }
 
-  override def deploymentHistory(environments: Option[Array[String]], services: Option[Array[String]], limit: Int): Seq[Deploy] =
+  override def deploymentHistory(environments: Option[Array[String]],
+                                 services: Option[Array[String]],
+                                 limit: Int): Seq[Deploy] =
     db.withSession { implicit session =>
-      //dao.deploymentHistory(environment, service, limit)
       dao.deploymentHistory(environments, services, limit)
     }
 }

--- a/src/main/scala/com/socrata/decima/database/DeployDAO.scala
+++ b/src/main/scala/com/socrata/decima/database/DeployDAO.scala
@@ -42,7 +42,9 @@ class DeployDAO extends DeployTable with Logging {
     res.map(rowToModelDeploy)
   }
 
-  def currentDeployment(environments: Option[Array[String]], services: Option[Array[String]])(implicit session:Session): Seq[Deploy] = {
+  def currentDeployment(environments: Option[Array[String]],
+                        services: Option[Array[String]])
+                       (implicit session:Session): Seq[Deploy] = {
     val res = currentDeploymentQuery.list.filter(row => environments match {
       case Some(e) => e.contains(row.environment)
       case None => true

--- a/src/main/scala/com/socrata/decima/database/DeployDAO.scala
+++ b/src/main/scala/com/socrata/decima/database/DeployDAO.scala
@@ -28,29 +28,28 @@ class DeployDAO extends DeployTable with Logging {
                                                                                     + id)))
   }
 
-  def deploymentHistory(environment: Option[String],
-                        service: Option[String],
+  def deploymentHistory(environments: Option[Array[String]],
+                        services: Option[Array[String]],
                         limit: Int = defaultHistoryLimit)(implicit session: Session): Seq[Deploy] = {
-    val res = deployTable.filter(row =>
-      environment match {
-        case Some(e) => row.environment === e
-        case None => LiteralColumn(true)
-      }).filter(row =>
-      service match {
-        case Some(s) => row.service === s
-        case None => LiteralColumn(true)
-      }).sortBy(_.deployedAt.desc).take(limit).run
+    val query = deployTable.filter(row => environments match {
+      case Some(e) => row.environment inSet e
+      case None => LiteralColumn(true)
+    }).filter(row => services match {
+      case Some(s) => row.service inSet s
+      case None => LiteralColumn(true)
+    }).sortBy(_.deployedAt.desc).take(limit)
+    val res = query.run
     res.map(rowToModelDeploy)
   }
 
-  def currentDeployment(environment: Option[String], service: Option[String])(implicit session:Session): Seq[Deploy] = {
-    val res = currentDeploymentQuery.list.filter(row => environment match {
-      case Some(e) => row.environment == e
+  def currentDeployment(environments: Option[Array[String]], services: Option[Array[String]])(implicit session:Session): Seq[Deploy] = {
+    val res = currentDeploymentQuery.list.filter(row => environments match {
+      case Some(e) => e.contains(row.environment)
       case None => true
-    }).filter(row => service match {
-      case Some(s) => row.service == s
+    }).filter(row => services match {
+      case Some(s) => s.contains(row.service)
       case None => true
-    })
+    }).sortBy(row => (row.environment, row.service))
     res.map(rowToModelDeploy)
   }
 }

--- a/src/main/scala/com/socrata/decima/services/DeployService.scala
+++ b/src/main/scala/com/socrata/decima/services/DeployService.scala
@@ -25,10 +25,10 @@ class DeployService(deployAccess:DeployAccess) extends DecimaStack {
    * environment: environment to return deploy information for
    */
   get("/") { // scalastyle:ignore multiple.string.literals
-    val serviceName = params.get(serviceParamKey)
-    val environmentName = params.get(environmentParamKey)
+    val services = params.get(serviceParamKey).map(_.split(","))
+    val environments = params.get(environmentParamKey).map(_.split(","))
 
-    deployAccess.currentDeploymentState(environmentName, serviceName)
+    deployAccess.currentDeploymentState(environments, services)
   }
 
   /**
@@ -54,10 +54,10 @@ class DeployService(deployAccess:DeployAccess) extends DecimaStack {
    * limit: override the default number of deploy events to return
    */
   get("/history") {
-    val serviceName = params.get(serviceParamKey)
-    val environmentName = params.get(environmentParamKey)
+    val services = params.get(serviceParamKey).map(_.split(","))
+    val environments = params.get(environmentParamKey).map(_.split(","))
     val limit = params.getOrElse(limitParamKey, defaultLimit.toString).toInt
 
-    deployAccess.deploymentHistory(environmentName, serviceName, limit)
+    deployAccess.deploymentHistory(environments, services, limit)
   }
 }

--- a/src/test/scala/com/socrata/decima/DeployServiceSpec.scala
+++ b/src/test/scala/com/socrata/decima/DeployServiceSpec.scala
@@ -41,7 +41,7 @@ class DeployServiceSpec extends ScalatraSuite with WordSpecLike with BeforeAndAf
     "return the correct number of deployed services" in {
       get("/deploy") {
         val deploys = parseResponse(response.body)
-        deploys.length should be (5)
+        deploys.length should be (6)
       }
     }
 
@@ -115,7 +115,7 @@ class DeployServiceSpec extends ScalatraSuite with WordSpecLike with BeforeAndAf
     "return the history of recent deploys" in {
       get("/deploy/history") {
         val deploys = parseResponse(response.body)
-        deploys.length should be (11)
+        deploys.length should be (12)
       }
     }
   }

--- a/src/test/scala/com/socrata/decima/SpecUtils.scala
+++ b/src/test/scala/com/socrata/decima/SpecUtils.scala
@@ -31,7 +31,8 @@ trait H2DBSpecUtils {
       DeployForCreate("frontend", "rc", "1.1.1", "blah", Option("blah"), Option("""{ "this": "is a config"}"""), "autoprod", "an engineer"),
       DeployForCreate("frontend", "staging", "1.1.2", "blah", Option("blah"), Option("""{ "this": "is a config"}"""), "autoprod", "an engineer"),
       DeployForCreate("frontend", "staging", "1.1.3", "blah", Option("blah"), Option("""{ "this": "is a config"}"""), "autoprod", "an engineer"),
-      DeployForCreate("frontend", "staging", "1.1.2", "blah", Option("blah"), Option("""{ "this": "is a config"}"""), "autoprod", "an engineer"))
+      DeployForCreate("frontend", "staging", "1.1.2", "blah", Option("blah"), Option("""{ "this": "is a config"}"""), "autoprod", "an engineer"),
+      DeployForCreate("phidippides", "staging", "0.13", "blah", Option("blah"), Option("""{ "this": "is a config"}"""), "autoprod", "an engineer"))
     // scalastyle:on line.size.limit
     deploys.foreach(dao.createDeploy)
   }


### PR DESCRIPTION
We have multiple environments that we may want to group together as one. For example:
* staging
* azure-staging

This enables queries such as `deploy?environment=staging,azure-staging` to return deploy events matching either environment. It also adds support for the same for services.