### PR TITLE
Update Decima to add capability to pull info from S3

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -45,7 +45,6 @@ object DecimaBuild extends Build {
         "org.postgresql"      % "postgresql"            % "9.4-1201-jdbc4",
         "org.slf4j"           % "slf4j-api"             % "1.7.10",
         "org.yaml"            % "snakeyaml"             % "1.15",
-        "org.scalatest"       %% "scalatest"            % "2.2.4"             % "test",
         "org.scalatra"        %% "scalatra-scalatest"   % ScalatraVersion     % "test",
         "com.h2database"      % "h2"                    % "1.4.180"           % "test"
       ),

--- a/project/build.scala
+++ b/project/build.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 import org.scalatra.sbt._
 import com.mojolly.scalate.ScalatePlugin._
-import sbtassembly.AssemblyKeys
+import sbtassembly.{MergeStrategy, AssemblyKeys}
 import AssemblyKeys._
 import sbtbuildinfo.BuildInfoKeys._
 import sbtbuildinfo.{BuildInfoKey, BuildInfoOption, BuildInfoPlugin}
@@ -28,26 +28,34 @@ object DecimaBuild extends Build {
       resolvers += "Socrata Cloudbees" at "https://repository-socrata-oss.forge.cloudbees.com/release",
       resolvers += Resolver.url("bintray-sbt-plugins", url("https://dl.bintray.com/sbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns),
       libraryDependencies ++= Seq(
-        "org.scalatra"        %% "scalatra"             % ScalatraVersion,
-        "org.scalatra"        %% "scalatra-scalate"     % ScalatraVersion,
-        "org.scalatra"        %% "scalatra-json"        % ScalatraVersion,
-        "org.json4s"          %% "json4s-jackson"       % Json4sVersion,
-        "org.json4s"          %% "json4s-ext"           % Json4sVersion,
+        "com.github.seratch"  %% "awscala"              % "0.5.+",
         "com.typesafe.slick"  %% "slick"                % "2.1.0",
-        "org.slf4j"           % "slf4j-api"             % "1.7.10",
         "org.clapper"         %% "grizzled-slf4j"       % "1.0.2",
+        "org.json4s"          %% "json4s-ext"           % Json4sVersion,
+        "org.json4s"          %% "json4s-jackson"       % Json4sVersion,
+        "org.scalatra"        %% "scalatra"             % ScalatraVersion,
+        "org.scalatra"        %% "scalatra-json"        % ScalatraVersion,
+        "org.scalatra"        %% "scalatra-scalate"     % ScalatraVersion,
         "c3p0"                % "c3p0"                  % "0.9.1.2",
         "ch.qos.logback"      % "logback-classic"       % "1.1.2"             % "runtime",
-        "org.eclipse.jetty"   % "jetty-webapp"          % JettyVersion        % "container;compile",
-        "org.eclipse.jetty"   % "jetty-plus"            % JettyVersion        % "container",
-        "javax.servlet"       % "javax.servlet-api"     % "3.1.0",
         "com.typesafe"        % "config"                % "1.2.1",
-        "org.postgresql"      % "postgresql"            % "9.4-1201-jdbc4",
+        "javax.servlet"       % "javax.servlet-api"     % "3.1.0",
+        "org.eclipse.jetty"   % "jetty-plus"            % JettyVersion        % "container",
+        "org.eclipse.jetty"   % "jetty-webapp"          % JettyVersion        % "container;compile",
         "org.liquibase"       % "liquibase-core"        % "3.3.3",
-        "org.scalatra"        %% "scalatra-scalatest"   % ScalatraVersion     % "test",
+        "org.postgresql"      % "postgresql"            % "9.4-1201-jdbc4",
+        "org.slf4j"           % "slf4j-api"             % "1.7.10",
+        "org.yaml"            % "snakeyaml"             % "1.15",
         "org.scalatest"       %% "scalatest"            % "2.2.4"             % "test",
+        "org.scalatra"        %% "scalatra-scalatest"   % ScalatraVersion     % "test",
         "com.h2database"      % "h2"                    % "1.4.180"           % "test"
       ),
+      assemblyMergeStrategy in assembly := {
+        case "mime.types" => MergeStrategy.first
+        case x =>
+          val oldStrategy = (assemblyMergeStrategy in assembly).value
+          oldStrategy(x)
+      },
       buildInfoKeys := Seq[BuildInfoKey](
         name,
         version,

--- a/project/build.scala
+++ b/project/build.scala
@@ -3,9 +3,8 @@ import Keys._
 import org.scalatra.sbt._
 import com.mojolly.scalate.ScalatePlugin._
 import sbtassembly.{MergeStrategy, AssemblyKeys}
-import AssemblyKeys._
-import sbtbuildinfo.BuildInfoKeys._
-import sbtbuildinfo.{BuildInfoKey, BuildInfoOption, BuildInfoPlugin}
+import sbtassembly.AssemblyKeys._
+import sbtbuildinfo.BuildInfoPlugin
 import scoverage.ScoverageSbtPlugin
 
 object DecimaBuild extends Build {
@@ -56,19 +55,9 @@ object DecimaBuild extends Build {
           val oldStrategy = (assemblyMergeStrategy in assembly).value
           oldStrategy(x)
       },
-      buildInfoKeys := Seq[BuildInfoKey](
-        name,
-        version,
-        scalaVersion,
-        sbtVersion,
-        BuildInfoKey.action("buildTime") { System.currentTimeMillis() },
-        BuildInfoKey.action("revision") { gitSha }),
-      buildInfoPackage := "com.socrata.decima",
-      buildInfoOptions += BuildInfoOption.ToMap,
       ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages := ".*ScalatraBootstrap;.*JettyLauncher;.*MigrateSchema;.*templates.*;.*Migration;"
     )
   ).enablePlugins(BuildInfoPlugin)
 
   lazy val gitSha = Process(Seq("git", "describe", "--always", "--dirty", "--long", "--abbrev=10")).!!.stripLineEnd
-
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,5 @@
 resolvers += "Socrata Cloudbees" at "https://repository-socrata-oss.forge.cloudbees.com/release"
 
 addSbtPlugin("com.mojolly.scalate" % "xsbt-scalate-generator" % "0.5.0")
-
 addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.3.5")
-
-addSbtPlugin("com.socrata" % "socrata-sbt-plugins" % "1.4.3")
-
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.4.0")
+addSbtPlugin("com.socrata" % "socrata-sbt-plugins" % "1.6.0")

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -16,6 +16,7 @@ import scala.slick.jdbc.JdbcBackend._
 class ScalatraBootstrap extends LifeCycle with Logging {
 
   val cpds = DataSourceFromConfig(DecimaConfig.db)
+  val s3 = S3AccessFromConfig(DecimaConfig.s3)
 
   /**
    * Initialize app and set routing configuration
@@ -24,7 +25,8 @@ class ScalatraBootstrap extends LifeCycle with Logging {
   override def init(context: ServletContext): Unit = {
     val db = Database.forDataSource(cpds)
     val deployAccess = new DeploymentAccessWithPostgres(db, new DeploymentDAO() with ActualPostgresDriver)
-    context.mount(new DeploymentService(deployAccess), "/deploy/*")
+    val s3Access = new S3Access(s3, DecimaConfig.s3.bucketName)
+    context.mount(new DeploymentService(deployAccess, s3Access), "/deploy/*")
     context.mount(new DecimaServlet, "/*")
   }
 

--- a/src/main/scala/com/socrata/decima/data_access/DeploymentAccess.scala
+++ b/src/main/scala/com/socrata/decima/data_access/DeploymentAccess.scala
@@ -1,6 +1,6 @@
 package com.socrata.decima.data_access
 
-import com.socrata.decima.database.{DeploymentDAO, DatabaseDriver}
+import com.socrata.decima.database.{DatabaseDriver, DeploymentDAO}
 import com.socrata.decima.models._
 
 import scala.slick.driver.PostgresDriver.simple.Database

--- a/src/main/scala/com/socrata/decima/data_access/S3Access.scala
+++ b/src/main/scala/com/socrata/decima/data_access/S3Access.scala
@@ -1,0 +1,54 @@
+package com.socrata.decima.data_access
+
+import awscala.s3.S3
+import com.socrata.decima.models.S3BuildInfo
+import grizzled.slf4j.Logging
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.Constructor
+
+trait S3AccessBase {
+  def listBuildPaths(project: String): List[String]
+  def getBuildInfo(project: String, buildId: String): S3BuildInfo
+}
+
+class S3Access(s3: S3, bucketName: String) extends S3AccessBase with Logging {
+  lazy val bucket = s3.bucket(bucketName)
+  lazy val yaml = new Yaml(new Constructor(classOf[S3BuildInfo]))
+
+  /**
+   * Get the list of build IDs from S3 of a project
+   * This does a little processing:
+   *  - List out everything under $project/
+   *  - Filters out everything that isn't a prefix (S3 objects aren't builds)
+   * @param project: the prefix of the project to use in finding the build
+   * @return a list of build prefixes, e.g. ["CoreServer/12341234_12", ...]
+   */
+  override def listBuildPaths(project: String): List[String] = {
+    val builds = s3.ls(bucket.get, s"$project/").filter(_.isLeft)
+    if (builds.isEmpty) throw new RuntimeException(s"Unable to find any builds under $project")
+    builds.map(_.left.get).toList
+  }
+
+  /**
+   * Retrieves the build_info.yml file from S3 and parses it into an instance of S3BuildInfo
+   * @param project
+   * @param buildId
+   * @return
+   */
+  override def getBuildInfo(project: String, buildId: String): S3BuildInfo = {
+    val fileKey = s"$project/$buildId/build_info.yml"
+    val s3Url = s"s3://$bucketName/$fileKey"
+    logger.info(s"Retrieving build info from $s3Url")
+    val buildInfoObject = s3.get(bucket.get, fileKey)
+    if (buildInfoObject.isEmpty) throw new RuntimeException(s"Unable to find the build info at $s3Url")
+    try {
+      val buildInfo = yaml.load(buildInfoObject.get.content).asInstanceOf[S3BuildInfo]
+      buildInfo.s3Url = s3Url
+      buildInfo
+    } catch {
+      case e: Exception =>
+        throw new RuntimeException("Unable to parse build_info.yml file (it may be incorrectly formatted):\n"
+          + e.getMessage)
+    }
+  }
+}

--- a/src/main/scala/com/socrata/decima/models/AutoprodInfo.scala
+++ b/src/main/scala/com/socrata/decima/models/AutoprodInfo.scala
@@ -1,0 +1,8 @@
+package com.socrata.decima.models
+
+case class AutoprodInfo(service: String,
+                        project: String,
+                        environment: String,
+                        buildId: Option[String],
+                        deployedBy: String,
+                        deployMethod: String)

--- a/src/main/scala/com/socrata/decima/models/S3BuildInfo.scala
+++ b/src/main/scala/com/socrata/decima/models/S3BuildInfo.scala
@@ -12,7 +12,6 @@ package com.socrata.decima.models
  */
 
 //scalastyle:off
-
 class S3BuildInfo () {
   var service: String = null
   var version: String = null

--- a/src/main/scala/com/socrata/decima/models/S3BuildInfo.scala
+++ b/src/main/scala/com/socrata/decima/models/S3BuildInfo.scala
@@ -1,0 +1,26 @@
+package com.socrata.decima.models
+
+/**
+ * S3BuildInfo is used to parse a YAML file using Java's snakeyaml class
+ * Because of this, we have to do sad things, like "service_sha" and defining
+ * setters explicitly.
+ *
+ * We also have to include the 'service' tag because some build_info files contain
+ * them. We don't use it for building the Deploy object though, because some builds
+ * end up building more than 1 service (for projects that have multiple services in the
+ * same Git repository).
+ */
+
+//scalastyle:off
+
+class S3BuildInfo () {
+  var service: String = null
+  var version: String = null
+  var service_sha: String = null
+  var configuration: String = null
+  var s3Url: String = null
+  def setService(s: String): Unit = { service = s }
+  def setVersion(s: String): Unit = { version = s }
+  def setService_sha(s: String): Unit = { service_sha = s }
+  def setConfiguration(s: String): Unit = { configuration = s }
+}

--- a/src/main/scala/com/socrata/decima/services/DecimaServlet.scala
+++ b/src/main/scala/com/socrata/decima/services/DecimaServlet.scala
@@ -1,6 +1,5 @@
 package com.socrata.decima.services
 
-import com.socrata.decima.BuildInfo
 import org.json4s.Formats
 import org.scalatra.ScalatraServlet
 import org.scalatra.json.JacksonJsonSupport
@@ -28,6 +27,6 @@ class DecimaServlet extends ScalatraServlet with JacksonJsonSupport {
 
   get("/version") {
     contentType = formats("json")
-    BuildInfo.toMap
+    buildinfo.BuildInfo.toJson
   }
 }

--- a/src/main/scala/com/socrata/decima/services/DecimaStack.scala
+++ b/src/main/scala/com/socrata/decima/services/DecimaStack.scala
@@ -1,15 +1,12 @@
 package com.socrata.decima.services
 
+import org.apache.http.HttpStatus
 import org.json4s._
 import org.scalatra._
 import org.scalatra.json.JacksonJsonSupport
 import org.slf4j.LoggerFactory
 
-// scalastyle:off multiple.string.literals
-// scalastyle:off magic.number
-
 trait DecimaStack extends ScalatraServlet with JacksonJsonSupport with ScalatraLogging {
-
   // Sets up automatic case class to JSON output serialization, required by
   // the JValueResult trait.
   protected implicit val jsonFormats: Formats = org.json4s.DefaultFormats ++ org.json4s.ext.JodaTimeSerializers.all
@@ -28,7 +25,7 @@ trait DecimaStack extends ScalatraServlet with JacksonJsonSupport with ScalatraL
   error {
     case e: Exception =>
       logger.error("Request error: ", e)
-      response.setStatus(500)
+      response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)
       InternalServerError(ErrorMessage(error = true,
                                         e.getClass.getSimpleName,
                                         e.getMessage,

--- a/src/main/scala/com/socrata/decima/services/DeploymentService.scala
+++ b/src/main/scala/com/socrata/decima/services/DeploymentService.scala
@@ -1,7 +1,7 @@
 package com.socrata.decima.services
 
 import com.socrata.decima.data_access._
-import com.socrata.decima.models.{AutoprodInfo, VerificationForCreate, DeployForCreate}
+import com.socrata.decima.models.{AutoprodInfo, DeployForCreate, VerificationForCreate}
 import com.socrata.decima.util.AutoprodUtils
 
 /**

--- a/src/main/scala/com/socrata/decima/util/AutoprodUtils.scala
+++ b/src/main/scala/com/socrata/decima/util/AutoprodUtils.scala
@@ -1,0 +1,33 @@
+package com.socrata.decima.util
+
+import com.socrata.decima.models._
+import grizzled.slf4j.Logging
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
+object AutoprodUtils extends Logging {
+
+  def getLatestBuild(buildIds: List[String]): String = {
+    buildIds.map(_.split("/").last).sortWith(numericSort).last
+  }
+
+  def infoToDeployModel(autoprodInfo: AutoprodInfo, buildInfo: S3BuildInfo): DeployForCreate = {
+    val configuration = ("build_configuration" -> buildInfo.configuration) ~
+                        ("s3_url" -> buildInfo.s3Url)
+    DeployForCreate(autoprodInfo.service,
+                    autoprodInfo.environment,
+                    buildInfo.version,
+                    None,
+                    buildInfo.service_sha,
+                    None,
+                    Option(compact(render(configuration))),
+                    autoprodInfo.deployedBy,
+                    autoprodInfo.deployMethod)
+  }
+
+  private def numericSort(id1: String, id2: String): Boolean = {
+    intFromBuildId(id1) < intFromBuildId(id2)
+  }
+
+  private def intFromBuildId(id: String): Int = id.split("_").head.toInt
+}

--- a/src/main/scala/com/socrata/decima/util/DataSourceFromConfig.scala
+++ b/src/main/scala/com/socrata/decima/util/DataSourceFromConfig.scala
@@ -2,7 +2,6 @@ package com.socrata.decima.util
 
 import com.mchange.v2.c3p0.ComboPooledDataSource
 import grizzled.slf4j.Logging
-import org.slf4j.LoggerFactory
 
 object DataSourceFromConfig extends Logging {
   def apply(dbConfig: DbConfig): ComboPooledDataSource = {

--- a/src/main/scala/com/socrata/decima/util/DecimaConfig.scala
+++ b/src/main/scala/com/socrata/decima/util/DecimaConfig.scala
@@ -12,6 +12,7 @@ object DecimaConfig {
 
   val app = new AppConfig(config, "decima")
   val db = new DbConfig(config, "c3p0")
+  val s3 = new S3Config(config, "s3")
 }
 
 class AppConfig(baseConfig: Config, root: String) {
@@ -24,4 +25,11 @@ class DbConfig(baseConfig: Config, root: String) {
   val jdbcUrl = config.getString("jdbcUrl")
   val user = config.getString("user")
   val password = config.getString("password")
+}
+
+class S3Config(baseConfig: Config, root: String) {
+  private val config = baseConfig.getConfig(root)
+  val accessKeyId = config.getString("accessKeyId")
+  val secretAccessKey = config.getString("secretAccessKey")
+  val bucketName = config.getString("bucketName")
 }

--- a/src/main/scala/com/socrata/decima/util/S3AccessFromConfig.scala
+++ b/src/main/scala/com/socrata/decima/util/S3AccessFromConfig.scala
@@ -1,0 +1,12 @@
+package com.socrata.decima.util
+
+import awscala._
+import awscala.s3._
+
+object S3AccessFromConfig {
+  def apply(s3Config: S3Config): S3 = {
+    implicit val region = Region.US_WEST_2
+    S3(s3Config.accessKeyId,
+        s3Config.secretAccessKey)
+  }
+}

--- a/src/test/scala/com/socrata/decima/DecimaServletSpec.scala
+++ b/src/test/scala/com/socrata/decima/DecimaServletSpec.scala
@@ -5,9 +5,6 @@ import org.json4s._
 import org.scalatest.FunSuiteLike
 import org.scalatra.test.scalatest._
 
-// scalastyle:off magic.number
-// scalastyle:off multiple.string.literals
-
 class DecimaServletSpec extends ScalatraSuite with FunSuiteLike {
 
   implicit val formats = DefaultFormats ++ org.json4s.ext.JodaTimeSerializers.all

--- a/src/test/scala/com/socrata/decima/DeploymentDAOSpec.scala
+++ b/src/test/scala/com/socrata/decima/DeploymentDAOSpec.scala
@@ -3,11 +3,7 @@ package com.socrata.decima
 import com.socrata.decima.models._
 import org.scalatest.{BeforeAndAfter, ShouldMatchers, WordSpec}
 
-// scalastyle:off multiple.string.literals
-// scalastyle:off magic.number
-
 class DeploymentDAOSpec extends WordSpec with ShouldMatchers with BeforeAndAfter with H2DBSpecUtils {
-
   import dao.driver.simple._ // scalastyle:ignore import.grouping
 
   before {

--- a/src/test/scala/com/socrata/decima/DeploymentServiceSpec.scala
+++ b/src/test/scala/com/socrata/decima/DeploymentServiceSpec.scala
@@ -10,12 +10,8 @@ import org.json4s.jackson.Serialization.write
 import org.scalatest._
 import org.scalatra.test.scalatest.ScalatraSuite
 
-// scalastyle:off multiple.string.literals
-// scalastyle:off magic.number
-
 class DeploymentServiceSpec extends ScalatraSuite with WordSpecLike with BeforeAndAfter
                         with ShouldMatchers with H2DBSpecUtils {
-
   import dao.driver.simple._ // scalastyle:ignore import.grouping
 
   implicit val formats = DefaultFormats ++ org.json4s.ext.JodaTimeSerializers.all
@@ -25,11 +21,11 @@ class DeploymentServiceSpec extends ScalatraSuite with WordSpecLike with BeforeA
   def parseDeployList(body: String): Seq[Deploy] = parse(body).camelizeKeys.extract[Seq[Deploy]]
 
   before {
-    setUpDb
+    setUpDb()
   }
 
   after {
-    cleanUpDb
+    cleanUpDb()
   }
 
   "The Deploy Service /deploy GET" should {

--- a/src/test/scala/com/socrata/decima/DeploymentServiceSpec.scala
+++ b/src/test/scala/com/socrata/decima/DeploymentServiceSpec.scala
@@ -1,13 +1,14 @@
 package com.socrata.decima
 
-import com.socrata.decima.data_access.{DeploymentAccessWithPostgres}
-import com.socrata.decima.models.{DeployForCreate, Deploy}
-import com.socrata.decima.services.{ErrorMessage, DeploymentService}
-import org.scalatest._
-import org.scalatra.test.scalatest.ScalatraSuite
+import com.socrata.decima.data_access.DeploymentAccessWithPostgres
+import com.socrata.decima.mocks.MockS3Access
+import com.socrata.decima.models.{AutoprodInfo, Deploy, DeployForCreate}
+import com.socrata.decima.services.{DeploymentService, ErrorMessage}
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import org.json4s.jackson.Serialization.write
+import org.scalatest._
+import org.scalatra.test.scalatest.ScalatraSuite
 
 // scalastyle:off multiple.string.literals
 // scalastyle:off magic.number
@@ -19,7 +20,7 @@ class DeploymentServiceSpec extends ScalatraSuite with WordSpecLike with BeforeA
 
   implicit val formats = DefaultFormats ++ org.json4s.ext.JodaTimeSerializers.all
   val deployAccess = new DeploymentAccessWithPostgres(db, dao)
-  addServlet(new DeploymentService(deployAccess), "/deploy/*")
+  addServlet(new DeploymentService(deployAccess, new MockS3Access), "/deploy/*")
 
   def parseDeployList(body: String): Seq[Deploy] = parse(body).camelizeKeys.extract[Seq[Deploy]]
 
@@ -108,8 +109,27 @@ class DeploymentServiceSpec extends ScalatraSuite with WordSpecLike with BeforeA
         val error = parse(response.body).camelizeKeys.extract[ErrorMessage]
         error.error should be (true)
       }
+    }
+  }
 
+  "The Deploy Service /deploy/autoprod" should {
+    "create a deploy event with info from autoprod" in {
+      val autoprod = AutoprodInfo("core", "CoreServer", "azure-staging", None, "an engineer", "autoprod")
+      put("/deploy/autoprod", write(parse(write(autoprod)).underscoreKeys)) {
+        status should be (200)
+        val deploy = parse(response.body).camelizeKeys.extract[Deploy]
+        deploy.configuration.get should include ("1234100_100")
+        deploy.version should be ("1.2.3")
+      }
+    }
 
+    "create a deploy of a specific build id from autoprod" in {
+      val autoprod = AutoprodInfo("core", "CoreServer", "azure-staging", Some("1234050_50"), "an engineer", "autoprod")
+      put("/deploy/autoprod", write(parse(write(autoprod)).underscoreKeys)) {
+        status should be (200)
+        val deploy = parse(response.body).camelizeKeys.extract[Deploy]
+        deploy.configuration.get should include ("1234050_50")
+      }
     }
   }
 

--- a/src/test/scala/com/socrata/decima/SpecUtils.scala
+++ b/src/test/scala/com/socrata/decima/SpecUtils.scala
@@ -1,6 +1,6 @@
 package com.socrata.decima
 
-import com.socrata.decima.database.{DeploymentDAO, DatabaseDriver}
+import com.socrata.decima.database.{DatabaseDriver, DeploymentDAO}
 import com.socrata.decima.models.DeployForCreate
 
 import scala.slick.driver.H2Driver

--- a/src/test/scala/com/socrata/decima/SpecUtils.scala
+++ b/src/test/scala/com/socrata/decima/SpecUtils.scala
@@ -16,7 +16,7 @@ trait H2DBSpecUtils {
 
   val dao = new DeploymentDAO with ActualH2Driver
   import dao.driver.simple._ // scalastyle:ignore import.grouping
-  val db = Database.forURL("jdbc:h2:mem:deploy_dao_test;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1",
+  val db = Database.forURL(s"jdbc:h2:mem:$getClass;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1",
     driver = "org.h2.Driver")
 
   def populateDeployDb(implicit session: Session): Unit = {

--- a/src/test/scala/com/socrata/decima/SpecUtils.scala
+++ b/src/test/scala/com/socrata/decima/SpecUtils.scala
@@ -5,15 +5,11 @@ import com.socrata.decima.models.DeployForCreate
 
 import scala.slick.driver.H2Driver
 
-// scalastyle:off multiple.string.literals
-// scalastyle:off magic.number
-
 trait ActualH2Driver extends DatabaseDriver {
   val driver = H2Driver
 }
 
 trait H2DBSpecUtils {
-
   val dao = new DeploymentDAO with ActualH2Driver
   import dao.driver.simple._ // scalastyle:ignore import.grouping
   val db = Database.forURL(s"jdbc:h2:mem:$getClass;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1",

--- a/src/test/scala/com/socrata/decima/mocks/MockS3Access.scala
+++ b/src/test/scala/com/socrata/decima/mocks/MockS3Access.scala
@@ -1,0 +1,24 @@
+package com.socrata.decima.mocks
+
+import com.socrata.decima.data_access.S3AccessBase
+import com.socrata.decima.models.S3BuildInfo
+
+
+class MockS3Access extends S3AccessBase {
+  override def listBuildPaths(project: String): List[String] = {
+    (1 to 100).toList.map(id =>
+      s"$project/${1234000 + id}_$id"
+    )
+  }
+
+  override def getBuildInfo(project: String, buildId: String): S3BuildInfo = {
+    val info = new S3BuildInfo()
+    info.configuration = "mock configuration"
+    info.s3Url = s"s3://build/$project/$buildId/build_info.yml"
+    info.service = project
+    info.service_sha = "asdfasdf"
+    info.version = "1.2.3"
+    info
+  }
+
+}


### PR DESCRIPTION
Currently, autoprod deployments don't have enough information to know
what is being deployed. This change will enable it to notify Decima of
the deployment information that it knows about (service, environment,
deployed by, and deploy method). Decima will then look for a
build_info.yml file on S3 and fill in the rest.