### PR TITLE
EN-5920: Update to decima-poller to java8

### DIFF
--- a/decima-poller/docker/Dockerfile
+++ b/decima-poller/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM socrata/java
+FROM socrata/java8
 
 # Service specific settings.
 ENV PROJECT_NAME decima-poller


### PR DESCRIPTION
This should make decima-poller run on java8.